### PR TITLE
implementing function "executeOldDhcpAction"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,5 +51,11 @@ Module.symvers
 Mkfile.old
 dkms.conf
 
+# Development
+.vscode/
+
 # My folders
 download/
+ipk/
+certificati/
+useful-file/

--- a/src/comms.c
+++ b/src/comms.c
@@ -48,13 +48,13 @@ int getOpenMudFile(char *mudFile, char *outputFile)
   char message[1000];
 
   curl_global_init(CURL_GLOBAL_DEFAULT);
-                logOmsGeneralMessage(OMS_DEBUG, OMS_SUBSYS_COMMUNICATION, "curl_easy_perform() doing it now....");
+  logOmsGeneralMessage(OMS_DEBUG, OMS_SUBSYS_COMMUNICATION, "curl_easy_perform() doing it now....");
 
   curl = curl_easy_init();
   if(curl) {
-	curlData.fileName = outputFile;
-	curlData.outputFile = fopen(outputFile, "w");
-	curlData.data = 1;
+    curlData.fileName = outputFile;
+    curlData.outputFile = fopen(outputFile, "w");
+    curlData.data = 1;
 
     curl_easy_setopt(curl, CURLOPT_URL, mudFile);
     curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, write_data);
@@ -79,10 +79,10 @@ int getOpenMudFile(char *mudFile, char *outputFile)
     retval = curl_easy_perform(curl);
 
     if(retval != CURLE_OK) {
-        sprintf(message, "curl_easy_perform() failed: %s\n", curl_easy_strerror(retval));
-		logOmsGeneralMessage(OMS_ERROR, OMS_SUBSYS_COMMUNICATION, message);
+      sprintf(message, "curl_easy_perform() failed: %s\n", curl_easy_strerror(retval));
+		  logOmsGeneralMessage(OMS_ERROR, OMS_SUBSYS_COMMUNICATION, message);
     } else {
-		logOmsGeneralMessage(OMS_DEBUG, OMS_SUBSYS_COMMUNICATION, "curl_easy_perform() success");
+		  logOmsGeneralMessage(OMS_DEBUG, OMS_SUBSYS_COMMUNICATION, "curl_easy_perform() success");
     }
 
     /* always cleanup */

--- a/src/dhcp_event.c
+++ b/src/dhcp_event.c
@@ -77,7 +77,7 @@ void doDhcpLegacyAction(DhcpEvent *dhcpEvent)
 
 int validateMudFileWithSig(DhcpEvent *dhcpEvent)
 {
-	int validSig = -1; /* Indicates invalid signature. 0 = valid sig, non-zero is specific signature validation error */
+	int validSig = INVALID_MUD_FILE_SIG; /* Indicates invalid signature. 0 = valid sig, non-zero is specific signature validation error */
 
 	logOmsGeneralMessage(OMS_DEBUG, OMS_SUBSYS_GENERAL, "IN ****NEW**** validateMudFileWithSig()");
 

--- a/src/mud_manager.c
+++ b/src/mud_manager.c
@@ -393,7 +393,7 @@ void executeOldDhcpAction(DhcpEvent *dhcpEvent)
 						logOmsGeneralMessage(OMS_DEBUG, OMS_SUBSYS_MUD_FILE, "--- EXTRA: diff failed! ---");
 					}
 					else {
-						diff = WEXITSTATUS(diff)
+						diff = WEXITSTATUS(diff);
 						snprintf(myLogMessage, logLen, " --- EXTRA: Real (?) diff value: <%d> --- ", diff);
 						logOmsGeneralMessage(OMS_DEBUG, OMS_SUBSYS_MUD_FILE, myLogMessage);
 					}

--- a/src/mud_manager.c
+++ b/src/mud_manager.c
@@ -348,6 +348,7 @@ void executeOldDhcpAction(DhcpEvent *dhcpEvent)
 	char tmpFile[MAXLINE];
 	char logMsgBuf[4096];
 	char* argument_list[] = {"diff", "file1", "file2", NULL};
+	char command_buffer[1000];
 	
 	buildDhcpEventContext(logMsgBuf, "OLD", dhcpEvent);
 	logOmsGeneralMessage(OMS_INFO, OMS_SUBSYS_GENERAL, logMsgBuf);
@@ -381,12 +382,14 @@ void executeOldDhcpAction(DhcpEvent *dhcpEvent)
 				if(!getOpenMudFile(dhcpEvent->mudFileURL, tmpFile)) {  // != 0 there is an error
 					// 3. Verify if the new MUD file is different from the old one
 					logOmsGeneralMessage(OMS_DEBUG, OMS_SUBSYS_COMMUNICATION, "Comparing the MUD files");
-					logOmsGeneralMessage(OMS_DEBUG, OMS_SUBSYS_COMMUNICATION, argument_list[0]);
-					argument_list[1] = dhcpEvent->mudFileStorageLocation;
-					logOmsGeneralMessage(OMS_DEBUG, OMS_SUBSYS_COMMUNICATION, argument_list[1]);
-					argument_list[2] = tmpFile;
-					logOmsGeneralMessage(OMS_DEBUG, OMS_SUBSYS_COMMUNICATION, argument_list[2]);
-					run_command(argument_list);
+					// logOmsGeneralMessage(OMS_DEBUG, OMS_SUBSYS_COMMUNICATION, argument_list[0]);
+					// argument_list[1] = dhcpEvent->mudFileStorageLocation;
+					// logOmsGeneralMessage(OMS_DEBUG, OMS_SUBSYS_COMMUNICATION, argument_list[1]);
+					// argument_list[2] = tmpFile;
+					// logOmsGeneralMessage(OMS_DEBUG, OMS_SUBSYS_COMMUNICATION, argument_list[2]);
+					snprintf(command_buffer, logLen, "diff %s %s", dhcpEvent->mudFileStorageLocation, tmpFile);
+					logOmsGeneralMessage(OMS_DEBUG, OMS_SUBSYS_COMMUNICATION, command_buffer);
+					diff = system(command_buffer);
 					// diff = compareFiles(dhcpEvent->mudFileStorageLocation, tmpFile, &line, &col);
 					if(diff==0)  // 4a. Same -> Do nothing
 						logOmsGeneralMessage(OMS_DEBUG, OMS_SUBSYS_MUD_FILE, "MUD file is not changed");

--- a/src/mud_manager.c
+++ b/src/mud_manager.c
@@ -341,9 +341,26 @@ void executeNewDhcpAction(DhcpEvent *dhcpEvent)
 	}
 }
 
+
+void executeDelDhcpAction(DhcpEvent *dhcpEvent)
+{
+	char logMsgBuf[4096];
+	buildDhcpEventContext(logMsgBuf, "DEL", dhcpEvent);
+	logOmsGeneralMessage(OMS_INFO, OMS_SUBSYS_GENERAL, logMsgBuf);
+
+	if (dhcpEvent)
+	{
+		removeFirewallIPRule(dhcpEvent->ipAddress, dhcpEvent->macAddress);
+		removeMudDbDeviceEntry(mudFileDataDirectory, dhcpEvent->ipAddress, dhcpEvent->macAddress);
+		commitAndApplyFirewallRules();
+	}
+}
+
+
 int mudFilesAreDifferent(char* oldMudFile, char* newMudFile)
 {	// If MUD files are equal returns 0
 	int diff = -1;
+	char command_buffer[1000];
 
 	// Verify if the new MUD file is different from the old one
 	logOmsGeneralMessage(OMS_DEBUG, OMS_SUBSYS_MUD_FILE, "Comparing the MUD files");
@@ -373,7 +390,6 @@ void executeOldDhcpAction(DhcpEvent *dhcpEvent)
 	int line, col;  // for keeping track of the differences among files
 	char tmpFile[MAXLINE];
 	char logMsgBuf[4096];
-	char command_buffer[1000];
 	
 	buildDhcpEventContext(logMsgBuf, "OLD", dhcpEvent);
 	logOmsGeneralMessage(OMS_INFO, OMS_SUBSYS_GENERAL, logMsgBuf);
@@ -427,21 +443,6 @@ void executeOldDhcpAction(DhcpEvent *dhcpEvent)
 		}
 	}
 }
-
-void executeDelDhcpAction(DhcpEvent *dhcpEvent)
-{
-	char logMsgBuf[4096];
-	buildDhcpEventContext(logMsgBuf, "DEL", dhcpEvent);
-	logOmsGeneralMessage(OMS_INFO, OMS_SUBSYS_GENERAL, logMsgBuf);
-
-	if (dhcpEvent)
-	{
-		removeFirewallIPRule(dhcpEvent->ipAddress, dhcpEvent->macAddress);
-		removeMudDbDeviceEntry(mudFileDataDirectory, dhcpEvent->ipAddress, dhcpEvent->macAddress);
-		commitAndApplyFirewallRules();
-	}
-}
-
 
 void
 executeOpenMudDhcpAction(DhcpEvent *dhcpEvent)

--- a/src/mud_manager.c
+++ b/src/mud_manager.c
@@ -35,6 +35,10 @@
 #include "mud_manager.h"
 #include "mudparser.h"
 
+// Just for logging purposes
+#define logLen 1000
+char myLogMessage[logLen];
+
 extern char *dnsWhiteListFile;
 extern int noFailOnMudValidation;
 
@@ -42,10 +46,6 @@ int dhcpNewEventCount = 0;
 int dhcpOldEventCount = 0;
 int dhcpDeleteEventCount = 0;
 int dhcpErrorEventCount = 0;
-
-// Just for logging purposes
-int logLen = 1000;
-char myLogMessage[logLen];
 
 
 void resetDhcpCounters()

--- a/src/mud_manager.c
+++ b/src/mud_manager.c
@@ -338,9 +338,9 @@ void executeOldDhcpAction(DhcpEvent *dhcpEvent)
 {
 	int line, col;  // for keeping track of the differences among files
 	int diff = 1;
-	char *tmpFile;
+	char tmpFile[4096]
 	char logMsgBuf[4096];
-	char myLogMessage[100];
+	char myLogMessage[4096];
 	
 	buildDhcpEventContext(logMsgBuf, "OLD", dhcpEvent);
 	logOmsGeneralMessage(OMS_INFO, OMS_SUBSYS_GENERAL, logMsgBuf);
@@ -353,13 +353,12 @@ void executeOldDhcpAction(DhcpEvent *dhcpEvent)
 		/* In this part we verify it the MUD file was changed. */
 		if (dhcpEvent->mudFileURL) {
 			dhcpEvent->mudFileStorageLocation = createStorageLocation(dhcpEvent->mudFileURL);
-			tmpFile = safe_malloc(sizeof(dhcpEvent->mudSigFileStorageLocation)+4);
-			tmpFile = strcat(dhcpEvent->mudSigFileStorageLocation, ".tmp");
-
 			snprintf(myLogMessage, 100, "EXTRA: The <mudURL> is %s", dhcpEvent->mudFileURL);
 			logOmsGeneralMessage(OMS_DEBUG, OMS_SUBSYS_GENERAL, myLogMessage);
 			snprintf(myLogMessage, 100, "EXTRA: The <mudFileStorageLocation> is %s", dhcpEvent->mudFileStorageLocation);
 			logOmsGeneralMessage(OMS_DEBUG, OMS_SUBSYS_GENERAL, myLogMessage);
+
+			tmpFile = strcat(dhcpEvent->mudSigFileStorageLocation, ".tmp");
 			snprintf(myLogMessage, 100, "EXTRA: The <tmpMUDFile> is %s", tmpFile);
 			logOmsGeneralMessage(OMS_DEBUG, OMS_SUBSYS_GENERAL, myLogMessage);
 

--- a/src/mud_manager.c
+++ b/src/mud_manager.c
@@ -338,7 +338,7 @@ void executeOldDhcpAction(DhcpEvent *dhcpEvent)
 {
 	int line, col;  // for keeping track of the differences among files
 	int diff = 1;
-	char tmpFile[4096]
+	char tmpFile[4096];
 	char logMsgBuf[8192];
 	int logLen = 8192;
 	char myLogMessage[logLen];

--- a/src/mud_manager.c
+++ b/src/mud_manager.c
@@ -340,6 +340,8 @@ void executeOldDhcpAction(DhcpEvent *dhcpEvent)
 	int diff = 1;
 	char *tmpFile;
 	char logMsgBuf[4096];
+	char myLogMessage[100];
+	
 	buildDhcpEventContext(logMsgBuf, "OLD", dhcpEvent);
 	logOmsGeneralMessage(OMS_INFO, OMS_SUBSYS_GENERAL, logMsgBuf);
 
@@ -351,7 +353,7 @@ void executeOldDhcpAction(DhcpEvent *dhcpEvent)
 		/* In this part we verify it the MUD file was changed. */
 		if (dhcpEvent->mudFileURL) {
 			dhcpEvent->mudFileStorageLocation = createStorageLocation(dhcpEvent->mudFileURL);
-			tmpFile = safe_malloc(sizeof(&dhcpEvent->mudSigFileStorageLocation)+4)
+			tmpFile = safe_malloc(sizeof(&dhcpEvent->mudSigFileStorageLocation)+4);
 
 			snprintf(myLogMessage, 100, "EXTRA: The <mudURL> is %s", dhcpEvent->mudFileURL);
 			logOmsGeneralMessage(OMS_DEBUG, OMS_SUBSYS_GENERAL, myLogMessage);
@@ -363,7 +365,7 @@ void executeOldDhcpAction(DhcpEvent *dhcpEvent)
 			// 1. Download the new MUD file 
 			if(!getOpenMudFile(dhcpEvent->mudFileURL, tmpFile)) {
 				// 2. Verify if the new MUD file is different from the old one
-				diff = compareFiles(dhcpEvent->mudFileStorageLocation, tmpFile, line, col)
+				diff = compareFiles(dhcpEvent->mudFileStorageLocation, tmpFile, &line, &col);
 				if(diff==0)  // 3a. Same -> Do nothing
 					logOmsGeneralMessage(OMS_DEBUG, OMS_SUBSYS_MUD_FILE, "MUD file is not changed");
 				else {  // 3b. Different

--- a/src/mud_manager.c
+++ b/src/mud_manager.c
@@ -339,7 +339,7 @@ void executeOldDhcpAction(DhcpEvent *dhcpEvent)
 	int line, col;  // for keeping track of the differences among files
 	int diff = 1;
 	char tmpFile[4096];
-	char logMsgBuf[8192];
+	char logMsgBuf[4096];
 	int logLen = 8192;
 	char myLogMessage[logLen];
 	

--- a/src/mud_manager.c
+++ b/src/mud_manager.c
@@ -420,7 +420,7 @@ void executeOldDhcpAction(DhcpEvent *dhcpEvent)
 			} else {
 				// 1. Dinamycally creating a string for containing the temporary file used to compare old with new MUD file
 				strncpy(tmpFile, dhcpEvent->mudFileStorageLocation, strlen(dhcpEvent->mudFileStorageLocation));
-				replaceExtension(tmpFile, ".tmp.json");
+				tmpFile = replaceExtension(tmpFile, ".tmp.json");
 				// snprintf(tmpFile, MAXLINE, "%s.tmp.json", dhcpEvent->mudFileStorageLocation);
 				// logOmsGeneralMessage(OMS_DEBUG, OMS_SUBSYS_GENERAL, tmpFile);				
 				snprintf(myLogMessage, logLen, "EXTRA: The tmpMUDFile is <%s>", tmpFile);

--- a/src/mud_manager.c
+++ b/src/mud_manager.c
@@ -354,7 +354,7 @@ void executeOldDhcpAction(DhcpEvent *dhcpEvent)
 		if (dhcpEvent->mudFileURL) {
 			dhcpEvent->mudFileStorageLocation = createStorageLocation(dhcpEvent->mudFileURL);
 			tmpFile = safe_malloc(sizeof(dhcpEvent->mudSigFileStorageLocation)+4);
-			tmpFile = strcat(dhcpEvent->mudSigFileStorageLocation, ".tmp")
+			tmpFile = strcat(dhcpEvent->mudSigFileStorageLocation, ".tmp");
 
 			snprintf(myLogMessage, 100, "EXTRA: The <mudURL> is %s", dhcpEvent->mudFileURL);
 			logOmsGeneralMessage(OMS_DEBUG, OMS_SUBSYS_GENERAL, myLogMessage);
@@ -364,10 +364,11 @@ void executeOldDhcpAction(DhcpEvent *dhcpEvent)
 			logOmsGeneralMessage(OMS_DEBUG, OMS_SUBSYS_GENERAL, myLogMessage);
 
 			// 0. Verify that the MUD file really exists
-			if(!access(dhcpEvent->mudFileStorageLocation, F_OK))
-				logOmsGeneralMessage(OMS_DEBUG, OMS_SUBSYS_MUD_FILE, "There is no MUD file called <%s>", dhcpEvent->mudFileStorageLocation);
+			if(!access(dhcpEvent->mudFileStorageLocation, F_OK)) {
+				snprintf(myLogMessage, 100, "There is no MUD file called <%s>", dhcpEvent->mudFileStorageLocation);
+				logOmsGeneralMessage(OMS_DEBUG, OMS_SUBSYS_MUD_FILE, myLogMessage);
 				executeNewDhcpAction(dhcpEvent);
-			else {
+			} else {
 			// 1. Download the new MUD file 
 				if(!getOpenMudFile(dhcpEvent->mudFileURL, tmpFile)) {  // != 0 there is an error
 					// 2. Verify if the new MUD file is different from the old one

--- a/src/mud_manager.c
+++ b/src/mud_manager.c
@@ -385,17 +385,25 @@ void executeOldDhcpAction(DhcpEvent *dhcpEvent)
 					logOmsGeneralMessage(OMS_DEBUG, OMS_SUBSYS_MUD_FILE, command_buffer);
 
 					snprintf(myLogMessage, logLen, " --- EXTRA: pre diff value: <%d> --- ", diff);
-					logOmsGeneralMessage(OMS_DEBUG, OMS_SUBSYS_COMMUNICATION, myLogMessage);
+					logOmsGeneralMessage(OMS_DEBUG, OMS_SUBSYS_MUD_FILE, myLogMessage);
 					diff = system(command_buffer);
 					snprintf(myLogMessage, logLen, " --- EXTRA: post diff value: <%d> --- ", diff);
 					logOmsGeneralMessage(OMS_DEBUG, OMS_SUBSYS_MUD_FILE, myLogMessage);
+					if (!WEXITSTATUS(diff)) {
+						logOmsGeneralMessage(OMS_DEBUG, OMS_SUBSYS_MUD_FILE, "EXTRA: diff failed!");
+					}
+					else {
+						diff = WEXITSTATUS(diff)
+						snprintf(myLogMessage, logLen, " --- EXTRA: Real (?) diff value: <%d> --- ", diff);
+						logOmsGeneralMessage(OMS_DEBUG, OMS_SUBSYS_MUD_FILE, myLogMessage);
+					}
 
 					if(diff==0)  // 4a. Same -> Do nothing
 						logOmsGeneralMessage(OMS_DEBUG, OMS_SUBSYS_MUD_FILE, "MUD file is not changed");
 					else {       // 4b. Different
 						logOmsGeneralMessage(OMS_DEBUG, OMS_SUBSYS_MUD_FILE, "MUD file changed!");
 						// 5. Delete the tmp file
-						// remove(tmpFile);
+						remove(tmpFile);
 						logOmsGeneralMessage(OMS_DEBUG, OMS_SUBSYS_MUD_FILE, "tmpFile deleted");
 						// 6. Delete old firewall rules (if present)
 						executeDelDhcpAction(dhcpEvent);

--- a/src/mud_manager.c
+++ b/src/mud_manager.c
@@ -390,7 +390,7 @@ void executeOldDhcpAction(DhcpEvent *dhcpEvent)
 					snprintf(myLogMessage, logLen, " --- EXTRA: post diff value: <%d> --- ", diff);
 					logOmsGeneralMessage(OMS_DEBUG, OMS_SUBSYS_MUD_FILE, myLogMessage);
 					if (!WEXITSTATUS(diff)) {
-						logOmsGeneralMessage(OMS_DEBUG, OMS_SUBSYS_MUD_FILE, "EXTRA: diff failed!");
+						logOmsGeneralMessage(OMS_DEBUG, OMS_SUBSYS_MUD_FILE, "--- EXTRA: diff failed! ---");
 					}
 					else {
 						diff = WEXITSTATUS(diff)

--- a/src/mud_manager.c
+++ b/src/mud_manager.c
@@ -339,8 +339,9 @@ void executeOldDhcpAction(DhcpEvent *dhcpEvent)
 	int line, col;  // for keeping track of the differences among files
 	int diff = 1;
 	char tmpFile[4096]
-	char logMsgBuf[4096];
-	char myLogMessage[4096];
+	char logMsgBuf[8192];
+	int logLen = 8192;
+	char myLogMessage[logLen];
 	
 	buildDhcpEventContext(logMsgBuf, "OLD", dhcpEvent);
 	logOmsGeneralMessage(OMS_INFO, OMS_SUBSYS_GENERAL, logMsgBuf);
@@ -353,18 +354,18 @@ void executeOldDhcpAction(DhcpEvent *dhcpEvent)
 		/* In this part we verify it the MUD file was changed. */
 		if (dhcpEvent->mudFileURL) {
 			dhcpEvent->mudFileStorageLocation = createStorageLocation(dhcpEvent->mudFileURL);
-			snprintf(myLogMessage, 100, "EXTRA: The <mudURL> is %s", dhcpEvent->mudFileURL);
+			snprintf(myLogMessage, logLen, "EXTRA: The <mudURL> is %s", dhcpEvent->mudFileURL);
 			logOmsGeneralMessage(OMS_DEBUG, OMS_SUBSYS_GENERAL, myLogMessage);
-			snprintf(myLogMessage, 100, "EXTRA: The <mudFileStorageLocation> is %s", dhcpEvent->mudFileStorageLocation);
+			snprintf(myLogMessage, logLen, "EXTRA: The <mudFileStorageLocation> is %s", dhcpEvent->mudFileStorageLocation);
 			logOmsGeneralMessage(OMS_DEBUG, OMS_SUBSYS_GENERAL, myLogMessage);
 
 			tmpFile = strcat(dhcpEvent->mudSigFileStorageLocation, ".tmp");
-			snprintf(myLogMessage, 100, "EXTRA: The <tmpMUDFile> is %s", tmpFile);
+			snprintf(myLogMessage, logLen, "EXTRA: The <tmpMUDFile> is %s", tmpFile);
 			logOmsGeneralMessage(OMS_DEBUG, OMS_SUBSYS_GENERAL, myLogMessage);
 
 			// 0. Verify that the MUD file really exists
 			if(!access(dhcpEvent->mudFileStorageLocation, F_OK)) {
-				snprintf(myLogMessage, 100, "There is no MUD file called <%s>", dhcpEvent->mudFileStorageLocation);
+				snprintf(myLogMessage, logLen, "There is no MUD file called <%s>", dhcpEvent->mudFileStorageLocation);
 				logOmsGeneralMessage(OMS_DEBUG, OMS_SUBSYS_MUD_FILE, myLogMessage);
 				executeNewDhcpAction(dhcpEvent);
 			} else {

--- a/src/mud_manager.c
+++ b/src/mud_manager.c
@@ -384,7 +384,7 @@ int mudFilesAreDifferent(char* oldMudFile, char* newMudFile)
 		logOmsGeneralMessage(OMS_DEBUG, OMS_SUBSYS_MUD_FILE, myLogMessage);
 	}
 	else {
-		logOmsGeneralMessage(OMS_DEBUG, OMS_SUBSYS_MUD_FILE, "EXTRA: Files are equal!", diffRetVal);
+		logOmsGeneralMessage(OMS_DEBUG, OMS_SUBSYS_MUD_FILE, "EXTRA: Files are equal!");
 	}
 	return diffRetVal;
 }

--- a/src/mud_manager.c
+++ b/src/mud_manager.c
@@ -359,7 +359,7 @@ void executeOldDhcpAction(DhcpEvent *dhcpEvent)
 			snprintf(myLogMessage, logLen, "EXTRA: The <mudFileStorageLocation> is %s", dhcpEvent->mudFileStorageLocation);
 			logOmsGeneralMessage(OMS_DEBUG, OMS_SUBSYS_GENERAL, myLogMessage);
 
-			tmpFile = strcat(dhcpEvent->mudSigFileStorageLocation, ".tmp");
+			snprintf(tmpFile, strlen(tmpFile), "%s.tmp", dhcpEvent->mudSigFileStorageLocation);
 			snprintf(myLogMessage, logLen, "EXTRA: The <tmpMUDFile> is %s", tmpFile);
 			logOmsGeneralMessage(OMS_DEBUG, OMS_SUBSYS_GENERAL, myLogMessage);
 

--- a/src/mud_manager.c
+++ b/src/mud_manager.c
@@ -383,11 +383,11 @@ void executeOldDhcpAction(DhcpEvent *dhcpEvent)
 					logOmsGeneralMessage(OMS_DEBUG, OMS_SUBSYS_MUD_FILE, "Comparing the MUD files");
 					snprintf(command_buffer, logLen, "diff %s %s", dhcpEvent->mudFileStorageLocation, tmpFile);
 					logOmsGeneralMessage(OMS_DEBUG, OMS_SUBSYS_MUD_FILE, command_buffer);
-					
-					sprint(myLogMessage, " --- EXTRA: pre diff value: <%d> --- ", diff);
+
+					snprintf(myLogMessage, logLen, " --- EXTRA: pre diff value: <%d> --- ", diff);
 					logOmsGeneralMessage(OMS_DEBUG, OMS_SUBSYS_COMMUNICATION, myLogMessage);
 					diff = system(command_buffer);
-					sprint(myLogMessage, " --- EXTRA: post diff value: <%d> --- ", diff);
+					snprintf(myLogMessage, logLen, " --- EXTRA: post diff value: <%d> --- ", diff);
 					logOmsGeneralMessage(OMS_DEBUG, OMS_SUBSYS_MUD_FILE, myLogMessage);
 
 					if(diff==0)  // 4a. Same -> Do nothing
@@ -395,7 +395,7 @@ void executeOldDhcpAction(DhcpEvent *dhcpEvent)
 					else {       // 4b. Different
 						logOmsGeneralMessage(OMS_DEBUG, OMS_SUBSYS_MUD_FILE, "MUD file changed!");
 						// 5. Delete the tmp file
-						remove(tmpFile);
+						// remove(tmpFile);
 						logOmsGeneralMessage(OMS_DEBUG, OMS_SUBSYS_MUD_FILE, "tmpFile deleted");
 						// 6. Delete old firewall rules (if present)
 						executeDelDhcpAction(dhcpEvent);

--- a/src/mud_manager.c
+++ b/src/mud_manager.c
@@ -364,7 +364,7 @@ void executeOldDhcpAction(DhcpEvent *dhcpEvent)
 			logOmsGeneralMessage(OMS_DEBUG, OMS_SUBSYS_GENERAL, myLogMessage);
 
 			// 0. Verify that the MUD file really exists
-			if(!access(dhcpEvent->mudFileStorageLocation, F_OK)) {
+			if(access(dhcpEvent->mudFileStorageLocation, F_OK) != 0) {
 				snprintf(myLogMessage, logLen, "There is no MUD file called <%s>", dhcpEvent->mudFileStorageLocation);
 				logOmsGeneralMessage(OMS_DEBUG, OMS_SUBSYS_MUD_FILE, myLogMessage);
 				executeNewDhcpAction(dhcpEvent);

--- a/src/mud_manager.c
+++ b/src/mud_manager.c
@@ -420,7 +420,7 @@ void executeOldDhcpAction(DhcpEvent *dhcpEvent)
 				executeNewDhcpAction(dhcpEvent);
 			} else {
 				// 1. Dinamycally creating a string for containing the temporary file used to compare old with new MUD file
-				tmpFile = replaceExtension(dhcpEvent->mudFileStorageLocation, ".tmp.json");
+				tmpFile = replaceExtension(dhcpEvent->mudFileStorageLocation, "tmp.json");
 				// strncpy(tmpFile, dhcpEvent->mudFileStorageLocation, strlen(dhcpEvent->mudFileStorageLocation));
 				// snprintf(tmpFile, MAXLINE, "%s.tmp.json", dhcpEvent->mudFileStorageLocation);
 				// logOmsGeneralMessage(OMS_DEBUG, OMS_SUBSYS_GENERAL, tmpFile);				

--- a/src/mud_manager.c
+++ b/src/mud_manager.c
@@ -428,7 +428,7 @@ void executeOldDhcpAction(DhcpEvent *dhcpEvent)
 
 				// 2. Download the new MUD file 
 				if(!getOpenMudFile(dhcpEvent->mudFileURL, tmpFile)) {  // != 0 there is an error
-					retValue = mudFilesAreDifferent(dhcpEvent->mudFileStorageLocation, tmpFile)
+					retValue = mudFilesAreDifferent(dhcpEvent->mudFileStorageLocation, tmpFile);
 					if(retValue != 0) {
 						logOmsGeneralMessage(OMS_DEBUG, OMS_SUBSYS_MUD_FILE, "MUD file changed!");
 						// 3. Delete old firewall rules (if present)

--- a/src/mud_manager.c
+++ b/src/mud_manager.c
@@ -344,10 +344,9 @@ void executeNewDhcpAction(DhcpEvent *dhcpEvent)
 void executeOldDhcpAction(DhcpEvent *dhcpEvent)
 {
 	int line, col;  // for keeping track of the differences among files
-	int diff = 1;
+	int diff = -1;
 	char tmpFile[MAXLINE];
 	char logMsgBuf[4096];
-	char* argument_list[] = {"diff", "file1", "file2", NULL};
 	char command_buffer[1000];
 	
 	buildDhcpEventContext(logMsgBuf, "OLD", dhcpEvent);
@@ -381,29 +380,29 @@ void executeOldDhcpAction(DhcpEvent *dhcpEvent)
 				// 2. Download the new MUD file 
 				if(!getOpenMudFile(dhcpEvent->mudFileURL, tmpFile)) {  // != 0 there is an error
 					// 3. Verify if the new MUD file is different from the old one
-					logOmsGeneralMessage(OMS_DEBUG, OMS_SUBSYS_COMMUNICATION, "Comparing the MUD files");
-					// logOmsGeneralMessage(OMS_DEBUG, OMS_SUBSYS_COMMUNICATION, argument_list[0]);
-					// argument_list[1] = dhcpEvent->mudFileStorageLocation;
-					// logOmsGeneralMessage(OMS_DEBUG, OMS_SUBSYS_COMMUNICATION, argument_list[1]);
-					// argument_list[2] = tmpFile;
-					// logOmsGeneralMessage(OMS_DEBUG, OMS_SUBSYS_COMMUNICATION, argument_list[2]);
+					logOmsGeneralMessage(OMS_DEBUG, OMS_SUBSYS_MUD_FILE, "Comparing the MUD files");
 					snprintf(command_buffer, logLen, "diff %s %s", dhcpEvent->mudFileStorageLocation, tmpFile);
-					logOmsGeneralMessage(OMS_DEBUG, OMS_SUBSYS_COMMUNICATION, command_buffer);
+					logOmsGeneralMessage(OMS_DEBUG, OMS_SUBSYS_MUD_FILE, command_buffer);
+					
+					sprint(myLogMessage, " --- EXTRA: pre diff value: <%d> --- ", diff);
+					logOmsGeneralMessage(OMS_DEBUG, OMS_SUBSYS_COMMUNICATION, myLogMessage);
 					diff = system(command_buffer);
-					// diff = compareFiles(dhcpEvent->mudFileStorageLocation, tmpFile, &line, &col);
+					sprint(myLogMessage, " --- EXTRA: post diff value: <%d> --- ", diff);
+					logOmsGeneralMessage(OMS_DEBUG, OMS_SUBSYS_MUD_FILE, myLogMessage);
+
 					if(diff==0)  // 4a. Same -> Do nothing
 						logOmsGeneralMessage(OMS_DEBUG, OMS_SUBSYS_MUD_FILE, "MUD file is not changed");
 					else {       // 4b. Different
-						logOmsGeneralMessage(OMS_DEBUG, OMS_SUBSYS_COMMUNICATION, "MUD file changed!");
+						logOmsGeneralMessage(OMS_DEBUG, OMS_SUBSYS_MUD_FILE, "MUD file changed!");
 						// 5. Delete the tmp file
-						remove(tmpFile);						
-						logOmsGeneralMessage(OMS_DEBUG, OMS_SUBSYS_COMMUNICATION, "tmpFile deleted");
+						remove(tmpFile);
+						logOmsGeneralMessage(OMS_DEBUG, OMS_SUBSYS_MUD_FILE, "tmpFile deleted");
 						// 6. Delete old firewall rules (if present)
 						executeDelDhcpAction(dhcpEvent);
-						logOmsGeneralMessage(OMS_DEBUG, OMS_SUBSYS_COMMUNICATION, "old FW rules deleted");
+						logOmsGeneralMessage(OMS_DEBUG, OMS_SUBSYS_MUD_FILE, "old FW rules deleted");
 						// 7. Install new firewall Rules (the MUD file will be downloaded again)
 						executeNewDhcpAction(dhcpEvent);
-						logOmsGeneralMessage(OMS_DEBUG, OMS_SUBSYS_COMMUNICATION, "new rules created");
+						logOmsGeneralMessage(OMS_DEBUG, OMS_SUBSYS_MUD_FILE, "new rules created");
 					}
 				} else {
 					logOmsGeneralMessage(OMS_ERROR, OMS_SUBSYS_MUD_FILE, "ERROR: ****OLD**** NO MUD FILE RETRIEVED!!!");

--- a/src/mud_manager.c
+++ b/src/mud_manager.c
@@ -203,7 +203,7 @@ int executeMudWithDhcpContext(DhcpEvent *dhcpEvent)
 
 	MudFileInfo *mudFile = parseMudFile(dhcpEvent->mudFileStorageLocation);
 	
-	snprintf(myLogMessage, logLen, "EXTRA: description mudfile is %s", mudFile->description);
+	snprintf(myLogMessage, logLen, "EXTRA: mudfile description: %s", mudFile->systeminfo);
 	logOmsGeneralMessage(OMS_INFO, OMS_SUBSYS_DEVICE_INTERFACE, myLogMessage);
 
 	// Loop over mud file and carry out actions

--- a/src/mud_manager.c
+++ b/src/mud_manager.c
@@ -393,7 +393,8 @@ void executeOldDhcpAction(DhcpEvent *dhcpEvent)
 {
 	int line, col;  // for keeping track of the differences among files
 	int retValue = -1;
-	char tmpFile[MAXLINE];
+	char* tmpFile;
+	// char tmpFile[MAXLINE];
 	char logMsgBuf[4096];
 	
 	buildDhcpEventContext(logMsgBuf, "OLD", dhcpEvent);
@@ -419,8 +420,8 @@ void executeOldDhcpAction(DhcpEvent *dhcpEvent)
 				executeNewDhcpAction(dhcpEvent);
 			} else {
 				// 1. Dinamycally creating a string for containing the temporary file used to compare old with new MUD file
-				strncpy(tmpFile, dhcpEvent->mudFileStorageLocation, strlen(dhcpEvent->mudFileStorageLocation));
-				tmpFile = replaceExtension(tmpFile, ".tmp.json");
+				tmpFile = replaceExtension(dhcpEvent->mudFileStorageLocation, ".tmp.json");
+				// strncpy(tmpFile, dhcpEvent->mudFileStorageLocation, strlen(dhcpEvent->mudFileStorageLocation));
 				// snprintf(tmpFile, MAXLINE, "%s.tmp.json", dhcpEvent->mudFileStorageLocation);
 				// logOmsGeneralMessage(OMS_DEBUG, OMS_SUBSYS_GENERAL, tmpFile);				
 				snprintf(myLogMessage, logLen, "EXTRA: The tmpMUDFile is <%s>", tmpFile);

--- a/src/mud_manager.c
+++ b/src/mud_manager.c
@@ -347,6 +347,7 @@ void executeOldDhcpAction(DhcpEvent *dhcpEvent)
 	int diff = 1;
 	char tmpFile[MAXLINE];
 	char logMsgBuf[4096];
+	char* argument_list[] = {"diff", "file1", "file2", NULL};
 	
 	buildDhcpEventContext(logMsgBuf, "OLD", dhcpEvent);
 	logOmsGeneralMessage(OMS_INFO, OMS_SUBSYS_GENERAL, logMsgBuf);
@@ -380,7 +381,13 @@ void executeOldDhcpAction(DhcpEvent *dhcpEvent)
 				if(!getOpenMudFile(dhcpEvent->mudFileURL, tmpFile)) {  // != 0 there is an error
 					// 3. Verify if the new MUD file is different from the old one
 					logOmsGeneralMessage(OMS_DEBUG, OMS_SUBSYS_COMMUNICATION, "Comparing the MUD files");
-					diff = compareFiles(dhcpEvent->mudFileStorageLocation, tmpFile, &line, &col);
+					logOmsGeneralMessage(OMS_DEBUG, OMS_SUBSYS_COMMUNICATION, argument_list[0]);
+					argument_list[1] = dhcpEvent->mudFileStorageLocation;
+					logOmsGeneralMessage(OMS_DEBUG, OMS_SUBSYS_COMMUNICATION, argument_list[1]);
+					argument_list[2] = tmpFile;
+					logOmsGeneralMessage(OMS_DEBUG, OMS_SUBSYS_COMMUNICATION, argument_list[2]);
+					run_command(argument_list);
+					// diff = compareFiles(dhcpEvent->mudFileStorageLocation, tmpFile, &line, &col);
 					if(diff==0)  // 4a. Same -> Do nothing
 						logOmsGeneralMessage(OMS_DEBUG, OMS_SUBSYS_MUD_FILE, "MUD file is not changed");
 					else {       // 4b. Different

--- a/src/mud_manager.c
+++ b/src/mud_manager.c
@@ -341,7 +341,7 @@ void executeNewDhcpAction(DhcpEvent *dhcpEvent)
 	}
 }
 
-int mudFilesAreDifferent(oldMudFile, newMudFile)
+int mudFilesAreDifferent(char* oldMudFile, char* newMudFile)
 {	// If MUD files are equal returns 0
 	int diff = -1;
 

--- a/src/mud_manager.c
+++ b/src/mud_manager.c
@@ -343,11 +343,12 @@ void executeNewDhcpAction(DhcpEvent *dhcpEvent)
 
 int mudFilesAreDifferent(oldMudFile, newMudFile)
 {	// If MUD files are equal returns 0
-	
+	int diff = -1;
+
 	// Verify if the new MUD file is different from the old one
 	logOmsGeneralMessage(OMS_DEBUG, OMS_SUBSYS_MUD_FILE, "Comparing the MUD files");
 
-	snprintf(command_buffer, logLen, "diff %s %s", oldMudFile, tmpFile);
+	snprintf(command_buffer, logLen, "diff %s %s", oldMudFile, newMudFile);
 	logOmsGeneralMessage(OMS_DEBUG, OMS_SUBSYS_MUD_FILE, command_buffer);
 
 	snprintf(myLogMessage, logLen, " --- EXTRA: pre diff value: <%d> --- ", diff);
@@ -370,7 +371,6 @@ int mudFilesAreDifferent(oldMudFile, newMudFile)
 void executeOldDhcpAction(DhcpEvent *dhcpEvent)
 {
 	int line, col;  // for keeping track of the differences among files
-	int diff = -1;
 	char tmpFile[MAXLINE];
 	char logMsgBuf[4096];
 	char command_buffer[1000];

--- a/src/mud_manager.c
+++ b/src/mud_manager.c
@@ -380,7 +380,8 @@ int mudFilesAreDifferent(char* oldMudFile, char* newMudFile)
 	
 	if (diffRetVal != 0) {
 		diffRetVal = WEXITSTATUS(diffRetVal);
-		logOmsGeneralMessage(OMS_DEBUG, OMS_SUBSYS_MUD_FILE, "EXTRA: Files are different! diff returns: %d", diffRetVal);
+		snprintf(myLogMessage, LOG_MSG_BUF_LEN, "EXTRA: Files are different! diff returns: %d", diffRetVal);
+		logOmsGeneralMessage(OMS_DEBUG, OMS_SUBSYS_MUD_FILE, myLogMessage);
 	}
 	else {
 		logOmsGeneralMessage(OMS_DEBUG, OMS_SUBSYS_MUD_FILE, "EXTRA: Files are equal!", diffRetVal);

--- a/src/mud_manager.c
+++ b/src/mud_manager.c
@@ -370,7 +370,7 @@ int mudFilesAreDifferent(char* oldMudFile, char* newMudFile)
 	// Verify if the new MUD file is different from the old one
 	logOmsGeneralMessage(OMS_DEBUG, OMS_SUBSYS_MUD_FILE, "EXTRA: Comparing the MUD files");
 
-	snprintf(command_buffer, LOG_MSG_BUF_LEN, "diff %s %s", oldMudFile, newMudFile);
+	snprintf(command_buffer, LOG_MSG_BUF_LEN, "diff %s %s > /dev/null", oldMudFile, newMudFile);
 	command_buffer[LOG_MSG_BUF_LEN-1] = '\0';
 	logOmsGeneralMessage(OMS_DEBUG, OMS_SUBSYS_MUD_FILE, command_buffer);
 	diffRetVal = system(command_buffer);

--- a/src/oms_utils.c
+++ b/src/oms_utils.c
@@ -329,3 +329,47 @@ FILE *fopen_with_path(char *path, char *mode)
     else
     	return (FILE *)0;
 }
+
+/**
+ * Function to compare two files.
+ * Returns 0 if both files are equivalent, otherwise returns
+ * -1 and sets line and col where both file differ.
+ */
+int compareFiles(char* filePath1, char* filePath2, int* line, int* col)
+{
+    FILE* fPtr1; FILE* fPtr2;
+    char ch1, ch2;
+    *line = 1; *col = 0;
+
+    // Opening files
+    fPtr1 = fopen(filePath1, "r");
+    fPtr2 = fopen(filePath2, "r");
+
+    do {
+        // Input character from both files
+        ch1 = fgetc(fPtr1);
+        ch2 = fgetc(fPtr2);
+        
+        // Increment line 
+        if (ch1 == '\n') {
+            *line += 1;
+            *col = 0;
+        }
+
+        // If characters are not same then return -1
+        if (ch1 != ch2)
+            return -1;
+
+        *col  += 1;
+
+    } while (ch1 != EOF && ch2 != EOF);
+
+    // Closing files
+    fclose(fPtr1); fclose(fPtr2);
+
+    /* If both files have reached end */
+    if (ch1 == EOF && ch2 == EOF)
+        return 0;
+    else
+        return -1;
+}

--- a/src/oms_utils.h
+++ b/src/oms_utils.h
@@ -29,5 +29,6 @@ int run_command(char **args);
 int run_command_with_output_logged(char *fullCommandLine);
 int mkdir_path(char *path);
 FILE *fopen_with_path( char *path, char *mode );
+int compareFiles(char* filePath1, char* filePath2, int* line, int* col);
 
 #endif

--- a/src/openwrt/openwrt.c
+++ b/src/openwrt/openwrt.c
@@ -244,7 +244,7 @@ int verifyCmsSignature(char *mudFileLocation, char *mudSigFileLocation)
 	logOmsGeneralMessage(OMS_DEBUG, OMS_SUBSYS_GENERAL, logMessage);
 	
 
-	snprintf(execBuf, BUFSIZE, "openssl cms -verify -in %s -inform DER -content %s -purpose any 2>> /var/log/mud_signature_failures.txt", mudSigFileLocation, mudFileLocation);
+	snprintf(execBuf, BUFSIZE, "openssl cms -verify -in %s -inform DER -content %s -purpose any >> /var/log/mud_signature_failures.txt 2>&1", mudSigFileLocation, mudFileLocation);
 	execBuf[BUFSIZE-1] = '\0';
 	logOmsGeneralMessage(OMS_DEBUG, OMS_SUBSYS_GENERAL, execBuf);
 	retval = system(execBuf);

--- a/src/openwrt/openwrt.c
+++ b/src/openwrt/openwrt.c
@@ -236,14 +236,28 @@ int verifyCmsSignature(char *mudFileLocation, char *mudSigFileLocation)
 	char logMessage[BUFSIZE];
 	int retval, sigStatus;
 
-	snprintf(execBuf, BUFSIZE, "openssl cms -verify -in %s -inform DER -content %s -purpose any", mudSigFileLocation, mudFileLocation);
+	snprintf(execBuf, BUFSIZE, "ls &> /tmp/ls_result.txt");
+	execBuf[BUFSIZE-1] = '\0';
+	retval = system(execBuf);
+	if (!WEXITSTATUS(retval)) {
+		logOmsGeneralMessage(OMS_DEBUG, OMS_SUBSYS_MUD_FILE, "--- EXTRA: ls probably failed! ---");
+	}
+	snprintf(logMessage, BUFSIZE, "ls returns %d", retval);
+	logOmsGeneralMessage(OMS_DEBUG, OMS_SUBSYS_GENERAL, logMessage);
+	
+
+	snprintf(execBuf, BUFSIZE, "openssl cms -verify -in %s -inform DER -content %s -purpose any &> /tmp/signature_result.txt", mudSigFileLocation, mudFileLocation);
 	execBuf[BUFSIZE-1] = '\0';
 
 	logOmsGeneralMessage(OMS_DEBUG, OMS_SUBSYS_GENERAL, execBuf);
 	retval = system(execBuf);
-
+	if (!WEXITSTATUS(retval)) {
+		logOmsGeneralMessage(OMS_DEBUG, OMS_SUBSYS_MUD_FILE, "--- EXTRA: Signature probably failed! ---");
+	}
 	snprintf(logMessage, BUFSIZE, "Signature verification returns %d", retval);
 	logOmsGeneralMessage(OMS_DEBUG, OMS_SUBSYS_GENERAL, logMessage);
+	
+	
 	/* A non-zero return value indicates the signature on the mud file was invalid */
 	if (retval != 0) {
 		logOmsGeneralMessage(OMS_ERROR, OMS_SUBSYS_DEVICE_INTERFACE, execBuf);

--- a/src/openwrt/openwrt.c
+++ b/src/openwrt/openwrt.c
@@ -233,6 +233,7 @@ int verifyCmsSignature(char *mudFileLocation, char *mudSigFileLocation)
 	/* openssl cms -verify -in mudfile.p7s -inform DER -content badtxt */
 
 	char execBuf[BUFSIZE];
+	char logMessage[BUFSIZE];
 	int retval, sigStatus;
 
 	snprintf(execBuf, BUFSIZE, "openssl cms -verify -in %s -inform DER -content %s -purpose any", mudSigFileLocation, mudFileLocation);
@@ -241,8 +242,10 @@ int verifyCmsSignature(char *mudFileLocation, char *mudSigFileLocation)
 	logOmsGeneralMessage(OMS_DEBUG, OMS_SUBSYS_GENERAL, execBuf);
 	retval = system(execBuf);
 
+	snprintf(logMessage, BUFSIZE, "Signature verification returns %d", retval);
+	logOmsGeneralMessage(OMS_DEBUG, OMS_SUBSYS_GENERAL, logMessage);
 	/* A non-zero return value indicates the signature on the mud file was invalid */
-	if (retval) {
+	if (retval != 0) {
 		logOmsGeneralMessage(OMS_ERROR, OMS_SUBSYS_DEVICE_INTERFACE, execBuf);
 		sigStatus = INVALID_MUD_FILE_SIG;
 	}

--- a/src/osmud.c
+++ b/src/osmud.c
@@ -181,7 +181,8 @@ void doProcessLoop(FD filed)
 void printVersion()
 {
 	printf("osmud\n");
-	printf("    Version: %s\n", build_git_sha);
+	printf("    Version: %s\n", build_version);
+	printf("    Last Commit: %s\n", build_git_sha);
 	printf("    Build Date: %s\n", build_git_time);
 }
 
@@ -217,16 +218,16 @@ int writePidFile(pid_t osMudPid) {
 	fp = fopen_with_path(osmudPidFile, "w");
 
 	if (fp != NULL)
-        {
-            fprintf(fp, "%d\n", osMudPid);
-
-            fflush(fp);
-            fclose(fp);
-        }
-        else
 	{
-            logOmsGeneralMessage(OMS_CRIT, OMS_SUBSYS_DEVICE_INTERFACE, "Could not write to PID file.");
-            retval = 1;
+		fprintf(fp, "%d\n", osMudPid);
+
+		fflush(fp);
+		fclose(fp);
+	}
+	else
+	{
+		logOmsGeneralMessage(OMS_CRIT, OMS_SUBSYS_DEVICE_INTERFACE, "Could not write to PID file.");
+		retval = 1;
 	}
 
 	return retval;

--- a/src/osmud.c
+++ b/src/osmud.c
@@ -237,7 +237,7 @@ int writePidFile(pid_t osMudPid) {
 void logInitialSettings()
 {
 	char msgBuf[LOG_MSG_BUF_LEN];
-	sprintf(msgBuf, "OsMUD\n Version: %s\n Build Date: %s\n Last Commit: %s", build_version, build_git_time, build_git_sha);
+	sprintf(msgBuf, "\nOsMUD\n Version: %s\n Build Date: %s\n Last Commit: %s", build_version, build_git_time, build_git_sha);
 	logOmsGeneralMessage(OMS_INFO, OMS_SUBSYS_GENERAL, msgBuf);
 	logOmsGeneralMessage(OMS_INFO, OMS_SUBSYS_GENERAL, "  Starting OSMUD controlling with initial settings:");
 

--- a/src/osmud.c
+++ b/src/osmud.c
@@ -33,6 +33,7 @@
 #include "version.h"
 
 #define MAXLINE 1024
+#define LOG_MSG_BUF_LEN 4096
 
 /* Default locations for osMUD resources based on OpenWRT */
 #define MUD_FILE_DIRECTORY "/var/state/osmud/mudfiles"
@@ -235,7 +236,9 @@ int writePidFile(pid_t osMudPid) {
 
 void logInitialSettings()
 {
-	char msgBuf[4096];
+	char msgBuf[LOG_MSG_BUF_LEN];
+	sprintf(msgBuf, "OsMUD\n Version: %s\n Build Date: %s\n Last Commit: %s", build_version, build_git_time, build_git_sha);
+	logOmsGeneralMessage(OMS_INFO, OMS_SUBSYS_GENERAL, msgBuf);
 	logOmsGeneralMessage(OMS_INFO, OMS_SUBSYS_GENERAL, "  Starting OSMUD controlling with initial settings:");
 
 	sprintf(msgBuf, "    PID FILE: %s", osmudPidFile);

--- a/src/version.c
+++ b/src/version.c
@@ -1,3 +1,7 @@
 #include "version.h"
-const char * build_git_sha = "08144c12696f8821ec3b6c1a1dc8368635c09d77";
-const char * build_git_time = "Thu Sep 27 17:48:08 EDT 2018";
+
+const char * build_version = "0.2.2";
+// const char * getLastSHA = "git log --pretty=format:'%H' -n 1";  // "08144c12696f8821ec3b6c1a1dc8368635c09d77";
+const char * build_git_sha =  "b351bf3acba7f4f618271c3f238315216ad941ee";
+// const char * getLastTime = "git log --pretty=format:'%aD' -n 1";  // "Thu Sep 27 17:48:08 EDT 2018";
+const char * build_git_time = "Wed, 5 Oct 2022 14:59:46 +02:00";

--- a/src/version.c
+++ b/src/version.c
@@ -2,6 +2,6 @@
 
 const char * build_version = "0.2.3";
 // const char * getLastSHA = "git log --pretty=format:'%H' -n 1";  // "08144c12696f8821ec3b6c1a1dc8368635c09d77";
-const char * build_git_sha =  "637132df1ec4e160615498bca8b981d181d1fae5";
+const char * build_git_sha =  "32ad9b0dabac99dd17ea225a761109447298991e";
 // const char * getLastTime = "git log --pretty=format:'%aD' -n 1";  // "Thu Sep 27 17:48:08 EDT 2018";
-const char * build_git_time = "Thu, 17 Nov 2022 19:23:15 +01:00";
+const char * build_git_time = "Fri, 18 Nov 2022 15:15:40 +01:00";

--- a/src/version.c
+++ b/src/version.c
@@ -1,7 +1,7 @@
 #include "version.h"
 
-const char * build_version = "0.2.2";
+const char * build_version = "0.2.3";
 // const char * getLastSHA = "git log --pretty=format:'%H' -n 1";  // "08144c12696f8821ec3b6c1a1dc8368635c09d77";
-const char * build_git_sha =  "b351bf3acba7f4f618271c3f238315216ad941ee";
+const char * build_git_sha =  "637132df1ec4e160615498bca8b981d181d1fae5";
 // const char * getLastTime = "git log --pretty=format:'%aD' -n 1";  // "Thu Sep 27 17:48:08 EDT 2018";
-const char * build_git_time = "Wed, 5 Oct 2022 14:59:46 +02:00";
+const char * build_git_time = "Thu, 17 Nov 2022 19:23:15 +01:00";

--- a/src/version.h
+++ b/src/version.h
@@ -16,6 +16,7 @@
 #ifndef _OMS_VERSION
 #define _OMS_VERSION
 
+extern const char * build_version;
 extern const char * build_git_sha;
 extern const char * build_git_time;
 


### PR DESCRIPTION
When the MUD manager receives a request from an OLD device with an associated MUD URL, the MUD manager retrieves the MUD file and verifies if it is different from the version already available.
If so, the old firewall rules are deleted and the rules contained in the new MUD file are enforced.